### PR TITLE
ci: update github action to connect to aws with oidc

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -2,6 +2,14 @@ on:
   push:
     branches:
       - main
+
+env:
+  AWS_REGION : eu-west-2
+
+permissions:
+      id-token: write
+      contents: read
+
 jobs:
   deploy:
     name: Build and upload to Amazon S3
@@ -9,10 +17,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
 
     - name: Install dependencies
       run: npm install
@@ -20,12 +30,12 @@ jobs:
     - name: Build website
       run: npm run-script build
 
-    - name: Configure AWS credentials from Test account
-      uses: aws-actions/configure-aws-credentials@v1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1.7.0
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
+        role-to-assume: arn:aws:iam::128707826079:role/DeployPersonalWebsite-GitHubAction
+        role-session-name: GitHub_to_AWS_via_FederatedOIDC
+        aws-region: ${{ env.AWS_REGION }}
 
     - name: Copy files to the test website with the AWS CLI
-      run: aws s3 sync build s3://callumlamont-test.com
+      run: aws s3 sync build s3://callumlamont.com


### PR DESCRIPTION
This PR fixes the CI pipeline to deploy the website. As part of this change, I decided to connect the GitHub to AWS with OIDC. GitHub requests a short term token to transfer the build files to S3. Now we don't need to store AWS credentials as GitHub secrets.