### PR TITLE
fix: delete old build files during s3 sync

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -37,5 +37,5 @@ jobs:
         role-session-name: GitHub_to_AWS_via_FederatedOIDC
         aws-region: ${{ env.AWS_REGION }}
 
-    - name: Copy files to the test website with the AWS CLI
-      run: aws s3 sync build s3://callumlamont.com
+    - name: Sync build to s3
+      run: aws s3 sync build s3://callumlamont.com --delete


### PR DESCRIPTION
Previously, old build files would persist when the s3 bucket was updated with the most recent website build. This commit prevents the behaviour by updating the aws cli command to use the --delete flag.